### PR TITLE
interrupt authentication checker thread on kill

### DIFF
--- a/src/main/java/com/samczsun/skype4j/internal/threads/AuthenticationChecker.java
+++ b/src/main/java/com/samczsun/skype4j/internal/threads/AuthenticationChecker.java
@@ -64,5 +64,6 @@ public class AuthenticationChecker extends Thread {
 
     public void kill() {
         this.stop.set(true);
+        this.interrupt();
     }
 }


### PR DESCRIPTION
AuthenticationChecker thread usually sleeps long that prevents applications from normal exit. For example, Windows Console applications waits for all threads to complete. Interrupting the thread fixes the issue like it's done in other threads of the project.
